### PR TITLE
fix: 청약 공고 페이지에 백 헤더 추가

### DIFF
--- a/src/components/subscription/SubscriptionCard.vue
+++ b/src/components/subscription/SubscriptionCard.vue
@@ -11,7 +11,9 @@
             <div class="flex items-center gap-2 flex-shrink-0">
                 <!-- D-Day 배지 -->
                 <span
-                    :class="getDDayBadgeClass(getDDayInfo(subscription.applicationCompleteDate).dDay)"
+                    :class="
+                        getDDayBadgeClass(getDDayInfo(subscription.applicationCompleteDate).dDay)
+                    "
                     class="text-xs font-semibold px-3 py-1 rounded-md"
                 >
                     {{ getDDayInfo(subscription.applicationCompleteDate).text }}
@@ -41,7 +43,8 @@
             <!-- 좌측: 날짜 정보 -->
             <div class="flex flex-col gap-4">
                 <span class="text-gray-500 text-sm">
-                    {{ subscription.applicationStartDate }} - {{ subscription.applicationCompleteDate }}
+                    {{ subscription.applicationStartDate }} -
+                    {{ subscription.applicationCompleteDate }}
                 </span>
                 <!-- 아파트 타입 버튼 -->
                 <button
@@ -76,28 +79,28 @@ import { Heart } from 'lucide-vue-next'
 
 // Props 정의
 const props = defineProps({
-  subscription: {
-    type: Object,
-    required: true,
-    default: () => ({
-      id: 1,
-      title: 'e편한세상 아파트',
-      location: '인천시 연수구 송도동',
-      totalUnits: 1000,
-      applicationStartDate: '2025.07.15',
-      applicationCompleteDate: '2025.07.17',
-      status: 'available',
-      type: '분양권',
-      priceRange: '12억',
-      completionDate: '2027.03',
-      features: ['역세권', '대단지']
-    })
-  },
-  favoriteDefault: {
-    type: Boolean,
-    default: false
-  }
-});
+    subscription: {
+        type: Object,
+        required: true,
+        default: () => ({
+            id: 1,
+            title: 'e편한세상 아파트',
+            location: '인천시 연수구 송도동',
+            totalUnits: 1000,
+            applicationStartDate: '2025.07.15',
+            applicationCompleteDate: '2025.07.17',
+            status: 'available',
+            type: '분양권',
+            priceRange: '12억',
+            completionDate: '2027.03',
+            features: ['역세권', '대단지'],
+        }),
+    },
+    favoriteDefault: {
+        type: Boolean,
+        default: false,
+    },
+})
 
 // 즐겨찾기 상태
 const isFavorite = ref(props.favoriteDefault)
@@ -179,12 +182,29 @@ const getHouseTypeBadgeClass = (type) => {
     }
 }
 
-// 이벤트 emit (부모 컴포넌트에서 사용할 경우)
-const emit = defineEmits(['favorite-changed', 'detail-click'])
-
 const handleDetailClick = () => {
     emit('detail-click', props.subscription)
 }
 
+import { useFavoritesStore } from '@/stores/favorites'; // 실제 사용시
 
+// Pinia 스토어 사용
+const favoritesStore = useFavoritesStore() // 실제 사용시
+
+// 현재 즐겨찾기 상태 (스토어에서 직접 가져오기)
+const isCurrentlyFavorite = computed(() => favoritesStore.isFavorite.value(props.subscription.id))
+
+const handleFavoriteClick = () => {
+    const newFavoriteState = favoritesStore.toggleFavorite(props.subscription.id)
+
+    // 부모 컴포넌트에 알림 (선택사항)
+    emit('favorite-changed', {
+        subscriptionId: props.subscription.id,
+        isFavorite: newFavoriteState,
+        subscription: props.subscription,
+    })
+}
+
+// 이벤트 emit
+const emit = defineEmits(['favorite-changed', 'detail-click'])
 </script>

--- a/src/pages/subscription/SubscriptionList.vue
+++ b/src/pages/subscription/SubscriptionList.vue
@@ -1,188 +1,178 @@
 <template>
-  <div class="flex flex-col min-h-screen bg-gray-50">
-    <!-- 헤더 -->
-    <div class="sticky top-0 bg-white border-b border-gray-200 px-4 py-4 z-10">
-      <h1 class="text-lg font-semibold text-gray-800 text-center">청약 공고 목록</h1>
-    </div>
+    <div class="flex flex-col min-h-screen bg-gray-50">
+        <!-- 헤더 -->
+        <BackHeader />
 
-    <!-- 필터 버튼들 (옵셔널) -->
-    <div class="px-4 py-3 bg-white border-b border-gray-100 ">
-      <div class="justify-center flex space-x-2 overflow-x-auto">
-        <button 
-          v-for="filter in filters" 
-          :key="filter.key"
-          @click="selectedFilter = filter.key"
-          :class="[
-            'px-4 py-2 rounded-full text-sm whitespace-nowrap transition-colors',
-            selectedFilter === filter.key 
-              ? 'bg-blue-500 text-white' 
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-          ]"
-        >
-          {{ filter.label }}
-        </button>
-      </div>
-    </div>
+        <!-- 필터 버튼들 (옵셔널) -->
+        <div class="px-4 py-3 bg-white border-b border-gray-100">
+            <div class="justify-center flex space-x-2 overflow-x-auto">
+                <button
+                    v-for="filter in filters"
+                    :key="filter.key"
+                    @click="selectedFilter = filter.key"
+                    :class="[
+                        'px-4 py-2 rounded-full text-sm whitespace-nowrap transition-colors',
+                        selectedFilter === filter.key
+                            ? 'bg-blue-500 text-white'
+                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+                    ]"
+                >
+                    {{ filter.label }}
+                </button>
+            </div>
+        </div>
 
-    <!-- 공고 목록 -->
-    <div class="flex-1 px-4 py-4 pb-20">
-      <div v-if="filteredSubscriptions.length === 0" class="text-center py-12">
-        <p class="text-gray-500">현재 표시할 청약 공고가 없습니다.</p>
-      </div>
-      
-      <div v-else class="space-y-4">
-        <SubscriptionCard 
-          v-for="subscription  in filteredSubscriptions" 
-          :key="subscription.id"
-          :subscription="subscription"
-        />
-      </div>
-    </div>
+        <!-- 공고 목록 -->
+        <div class="flex-1 px-4 py-4 pb-20">
+            <div v-if="filteredSubscriptions.length === 0" class="text-center py-12">
+                <p class="text-gray-500">현재 표시할 청약 공고가 없습니다.</p>
+            </div>
 
-    <BottomNavbar/>
-  </div>
+            <div v-else class="space-y-4">
+                <SubscriptionCard
+                    v-for="subscription in filteredSubscriptions"
+                    :key="subscription.id"
+                    :subscription="subscription"
+                />
+            </div>
+        </div>
+
+        <BottomNavbar />
+    </div>
 </template>
 
 <script setup>
 import { ref, computed } from 'vue'
-import BottomNavbar from '@/components/common/BottomNavbar.vue';
-import SubscriptionCard from '@/components/subscription/SubscriptionCard.vue';
+import BottomNavbar from '@/components/common/BottomNavbar.vue'
+import SubscriptionCard from '@/components/subscription/SubscriptionCard.vue'
+import BackHeader from '@/components/common/BackHeader.vue'
 
 const selectedFilter = ref('latest')
 
 const filters = [
-  { key: 'latest', label: '최신순' },
-  { key: 'deadline-first', label: '마감임박순' },
-  { key: 'filter', label: '필터', isCustom: true }
+    { key: 'latest', label: '최신순' },
+    { key: 'deadline-first', label: '마감임박순' },
+    { key: 'filter', label: '필터', isCustom: true },
 ]
-
 
 // 상세 필터 조건
 const customFilterOptions = [
-  { key: 'location', label: '지역' },
-  { key: 'price', label: '가격대' },
-  { key: 'area', label: '면적(평수)' },
+    { key: 'location', label: '지역' },
+    { key: 'price', label: '가격대' },
+    { key: 'area', label: '면적(평수)' },
 ]
-
 
 // 필터링된 청약 공고 목록
 const filteredSubscriptions = computed(() => {
-  let result = [...subscriptions.value];
-  
-  // 정렬 적용
-  switch (selectedFilter.value) {
-    case 'latest':
-      // 최신순 정렬 (신청 시작일이 빠른 순)
-      result.sort((a, b) => {
-        const aStartDate = new Date(a.applicationStartDate.replace(/\./g, '-'));
-        const bStartDate = new Date(b.applicationStartDate.replace(/\./g, '-'));
-        return aStartDate - bStartDate;
-      });
-      break;
-      
-    case 'deadline-first':
-      // 마감임박순 정렬 (마감일이 빠른 순)
-      result.sort((a, b) => {
-        const aCompleteDate = new Date(a.applicationCompleteDate.replace(/\./g, '-'));
-        const bCompleteDate = new Date(b.applicationCompleteDate.replace(/\./g, '-'));
-        return aCompleteDate - bCompleteDate;
-      });
-      break;
-      
-    default:
-      // 기본은 최신순
-      result.sort((a, b) => {
-        const aStartDate = new Date(a.applicationStartDate.replace(/\./g, '-'));
-        const bStartDate = new Date(b.applicationStartDate.replace(/\./g, '-'));
-        return aStartDate - bStartDate;
-      });
-  }
-  
-  return result;
-});
+    let result = [...subscriptions.value]
 
+    // 정렬 적용
+    switch (selectedFilter.value) {
+        case 'latest':
+            // 최신순 정렬 (신청 시작일이 빠른 순)
+            result.sort((a, b) => {
+                const aStartDate = new Date(a.applicationStartDate.replace(/\./g, '-'))
+                const bStartDate = new Date(b.applicationStartDate.replace(/\./g, '-'))
+                return aStartDate - bStartDate
+            })
+            break
+
+        case 'deadline-first':
+            // 마감임박순 정렬 (마감일이 빠른 순)
+            result.sort((a, b) => {
+                const aCompleteDate = new Date(a.applicationCompleteDate.replace(/\./g, '-'))
+                const bCompleteDate = new Date(b.applicationCompleteDate.replace(/\./g, '-'))
+                return aCompleteDate - bCompleteDate
+            })
+            break
+
+        default:
+            // 기본은 최신순
+            result.sort((a, b) => {
+                const aStartDate = new Date(a.applicationStartDate.replace(/\./g, '-'))
+                const bStartDate = new Date(b.applicationStartDate.replace(/\./g, '-'))
+                return aStartDate - bStartDate
+            })
+    }
+
+    return result
+})
 
 // 샘플 청약 공고 데이터
 const subscriptions = ref([
-  {
-    id: 1,
-    title: '힐스테이트 청라 국제도시',
-    location: '인천광역시 서구',
-    totalUnits: 1284,
-    applicationStartDate: '2025.08.15',
-    applicationCompleteDate: '2025.08.17',
-    status: 'available',
-    type: '아파트',
-    squareMeters: 104,
-    price: '12억',
-    completionDate: '2027.03',
-  },
-  {
-    id: 2,
-    title: '래미안 원베일리',
-    location: '서울특별시 강동구',
-    totalUnits: 758,
-    applicationStartDate: '2025.07.21',
-    applicationCompleteDate: '2025.07.22',
-    type: '오피스텔',
-    squareMeters: 74,
-    price: '18억',
-    completionDate: '2027.06',
-  },
-  {
-    id: 3,
-    title: '푸르지오 시티 동탄',
-    location: '경기도 화성시',
-    totalUnits: 2156,
-    applicationStartDate: '2025.08.08',
-    applicationCompleteDate: '2025.08.10',
-    type: '아파트',
-    squareMeters: 83,
-    price: '15억',
-    completionDate: '2027.09',
-  },
-  {
-    id: 4,
-    title: '자이 평촌 센트럴파크',
-    location: '경기도 안양시 동안구',
-    totalUnits: 924,
-    applicationStartDate: '2025.08.25',
-    applicationCompleteDate: '2025.08.27',
-    status: 'upcoming',
-    type: '도시형 생활주택',
-    squareMeters: 104,
-    price: '20억',
-    completionDate: '2027.12',
-  },
-  {
-    id: 5,
-    title: '롯데캐슬 베네시티',
-    location: '대구광역시 달서구',
-    totalUnits: 1456,
-    applicationStartDate: '2025.08.12',
-    applicationCompleteDate: '2025.08.14',
-    status: 'available',
-    type: '아파트',
-    squareMeters: 104,
-    price: '9억',
-    completionDate: '2027.08',
-  }
+    {
+        id: 1,
+        title: '힐스테이트 청라 국제도시',
+        location: '인천광역시 서구',
+        totalUnits: 1284,
+        applicationStartDate: '2025.08.15',
+        applicationCompleteDate: '2025.08.17',
+        status: 'available',
+        type: '아파트',
+        squareMeters: 104,
+        price: '12억',
+        completionDate: '2027.03',
+    },
+    {
+        id: 2,
+        title: '래미안 원베일리',
+        location: '서울특별시 강동구',
+        totalUnits: 758,
+        applicationStartDate: '2025.07.21',
+        applicationCompleteDate: '2025.07.22',
+        type: '오피스텔',
+        squareMeters: 74,
+        price: '18억',
+        completionDate: '2027.06',
+    },
+    {
+        id: 3,
+        title: '푸르지오 시티 동탄',
+        location: '경기도 화성시',
+        totalUnits: 2156,
+        applicationStartDate: '2025.08.08',
+        applicationCompleteDate: '2025.08.10',
+        type: '아파트',
+        squareMeters: 83,
+        price: '15억',
+        completionDate: '2027.09',
+    },
+    {
+        id: 4,
+        title: '자이 평촌 센트럴파크',
+        location: '경기도 안양시 동안구',
+        totalUnits: 924,
+        applicationStartDate: '2025.08.25',
+        applicationCompleteDate: '2025.08.27',
+        status: 'upcoming',
+        type: '도시형 생활주택',
+        squareMeters: 104,
+        price: '20억',
+        completionDate: '2027.12',
+    },
+    {
+        id: 5,
+        title: '롯데캐슬 베네시티',
+        location: '대구광역시 달서구',
+        totalUnits: 1456,
+        applicationStartDate: '2025.08.12',
+        applicationCompleteDate: '2025.08.14',
+        status: 'available',
+        type: '아파트',
+        squareMeters: 104,
+        price: '9억',
+        completionDate: '2027.08',
+    },
 ])
-
-
 
 // 필터 클릭 핸들러
 const handleFilterClick = (filter) => {
-  if (filter.isCustom) {
-    // 필터 버튼 클릭 시 모달이나 추가 옵션 표시 (추후 구현)
-    console.log('필터 옵션 열기');
-    // 여기에 모달 열기 로직 추가 가능
-  } else {
-    selectedFilter.value = filter.key;
-  }
-};
-
-
-
-
+    if (filter.isCustom) {
+        // 필터 버튼 클릭 시 모달이나 추가 옵션 표시 (추후 구현)
+        console.log('필터 옵션 열기')
+        // 여기에 모달 열기 로직 추가 가능
+    } else {
+        selectedFilter.value = filter.key
+    }
+}
 </script>

--- a/src/stores/favorites.js
+++ b/src/stores/favorites.js
@@ -1,0 +1,104 @@
+// stores/favorites.js
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export const useFavoritesStore = defineStore('favorites', () => {
+  // 상태 (State)
+  const favoriteIds = ref(new Set())
+  
+  // 게터 (Getters)
+  const favoritesCount = computed(() => favoriteIds.value.size)
+  
+  const favoriteIdsList = computed(() => Array.from(favoriteIds.value))
+  
+  const isFavorite = computed(() => (subscriptionId) => {
+    return favoriteIds.value.has(subscriptionId)
+  })
+
+  // 액션 (Actions)
+  const addToFavorites = (subscriptionId) => {
+    favoriteIds.value.add(subscriptionId)
+    saveFavoritesToStorage()
+    console.log(`즐겨찾기 추가: ${subscriptionId}`)
+  }
+
+  const removeFromFavorites = (subscriptionId) => {
+    favoriteIds.value.delete(subscriptionId)
+    saveFavoritesToStorage()
+    console.log(`즐겨찾기 제거: ${subscriptionId}`)
+  }
+
+  const toggleFavorite = (subscriptionId) => {
+    if (favoriteIds.value.has(subscriptionId)) {
+      removeFromFavorites(subscriptionId)
+      return false
+    } else {
+      addToFavorites(subscriptionId)
+      return true
+    }
+  }
+
+  const clearAllFavorites = () => {
+    favoriteIds.value.clear()
+    saveFavoritesToStorage()
+    console.log('모든 즐겨찾기 삭제')
+  }
+
+  // 즐겨찾기한 공고들 가져오기 (다른 스토어와 연동)
+  const getFavoriteSubscriptions = (allSubscriptions) => {
+    return allSubscriptions.filter(sub => favoriteIds.value.has(sub.id))
+  }
+
+  // 데이터 지속성 (실제 앱에서는 localStorage 또는 API)
+  const saveFavoritesToStorage = () => {
+    try {
+      // Claude.ai 환경에서는 localStorage 사용 불가이므로 콘솔로만 표시
+      const favoritesArray = Array.from(favoriteIds.value)
+      console.log('즐겨찾기 저장:', favoritesArray)
+      
+      // 실제 앱에서는 이렇게 사용:
+      // localStorage.setItem('favorites', JSON.stringify(favoritesArray))
+    } catch (error) {
+      console.error('즐겨찾기 저장 실패:', error)
+    }
+  }
+
+  const loadFavoritesFromStorage = () => {
+    try {
+      // 실제 앱에서는 이렇게 사용:
+      // const saved = localStorage.getItem('favorites')
+      // const favoritesArray = saved ? JSON.parse(saved) : []
+      
+      // 임시로 샘플 데이터 로드
+      const favoritesArray = [1, 3] // 샘플: 1번, 3번이 즐겨찾기
+      favoriteIds.value = new Set(favoritesArray)
+      console.log('즐겨찾기 로드:', favoritesArray)
+    } catch (error) {
+      console.error('즐겨찾기 로드 실패:', error)
+      favoriteIds.value = new Set()
+    }
+  }
+
+  // 스토어 초기화시 데이터 로드
+  const initializeFavorites = () => {
+    loadFavoritesFromStorage()
+  }
+
+  return {
+    // 상태
+    favoriteIds,
+    
+    // 게터
+    favoritesCount,
+    favoriteIdsList,
+    isFavorite,
+    
+    // 액션
+    addToFavorites,
+    removeFromFavorites,
+    toggleFavorite,
+    clearAllFavorites,
+    getFavoriteSubscriptions,
+    initializeFavorites
+  }
+})


### PR DESCRIPTION


## ✨ 변경 사항
- 청약 공고 페이지에 백 헤더 추가

---

## 🧪 테스트 방법
1. `/subscroptions` 페이지로 이동
2. 상단 헤더 확인

---

## 🔍 관련 이슈
-  #42  (청약 공고 카드 컴포넌트 제작)

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
