### PR TITLE
feat: integrate subscription list with new structure #175

### DIFF
--- a/src/pages/mypage/EditProfile.vue
+++ b/src/pages/mypage/EditProfile.vue
@@ -89,7 +89,9 @@
                 </button>
             </div>
 
-            <PrimaryButton>저장</PrimaryButton>
+            <PrimaryButton type="submit" :disabled="loading">{{
+                loading ? '저장 중...' : '저장'
+            }}</PrimaryButton>
         </form>
     </div>
 </template>

--- a/src/pages/subscription/SubscriptionList.vue
+++ b/src/pages/subscription/SubscriptionList.vue
@@ -125,8 +125,9 @@
             <div v-else class="space-y-4">
                 <SubscriptionCard
                     v-for="subscription in finalSubscriptions.slice(0, scrollIdx)"
-                    :key="subscription.house_nm"
+                    :key="subscription.pblanc_no"
                     :subscription="subscription"
+                    :showExpired="false"
                 />
             </div>
         </div>
@@ -178,6 +179,10 @@ const appliedFilters = ref({
 })
 const selectedAreas = ref([])
 
+const props = defineProps({
+    showExpired: { type: Boolean, default: false }, // 기본은 false
+})
+
 const sortStandards = [
     { key: 'latest', label: '최신순', icon: TrendingUp },
     { key: 'deadline-first', label: '마감임박순', icon: Clock },
@@ -218,12 +223,20 @@ const removeFilter = (type, index) => {
         appliedFilters.value.priceMax = null
     }
 }
+
+// 필터 적용 부분
 const applyFilters = () => {
     const parsedAreas = selectedAreas.value.map((val) =>
         typeof val === 'string' ? val.split(',').map(Number) : val,
     )
     appliedFilters.value = {
-        regions: [...selectedRegions.value],
+        regions: selectedRegions.value.map((r) => {
+            if (typeof r === 'string') {
+                const [city, district] = r.split(' ')
+                return { city, district: district || '__all__' }
+            }
+            return r
+        }),
         squareMeters: parsedAreas,
         priceMin: priceMin.value,
         priceMax: priceMax.value,
@@ -237,128 +250,94 @@ const finalSubscriptions = computed(() => {
         return []
 
     let result = [...subscriptionsStore.subscriptions]
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
 
-    // 1. 정렬
-    switch (selectedFilter.value) {
-        case 'latest':
-            result.sort((a, b) => {
-                const today = new Date()
-                today.setHours(0, 0, 0, 0)
-
-                const endA = new Date(a.application_end_date)
-                const endB = new Date(b.application_end_date)
-                const startA = new Date(a.application_start_date)
-                const startB = new Date(b.application_start_date)
-
-                const isExpiredA = endA < today
-                const isExpiredB = endB < today
-
-                if (isExpiredA && !isExpiredB) return 1
-                if (!isExpiredA && isExpiredB) return -1
-
-                return startA - startB
-            })
-            break
-        case 'deadline-first':
-            result.sort(
-                (a, b) => new Date(a.application_end_date) - new Date(b.application_end_date),
-            )
-            break
-        case 'recommend':
-            // 임시로 가격순 정렬
-            result.sort(
-                (a, b) =>
-                    (parseFloat(b.lttot_top_amount) || 0) - (parseFloat(a.lttot_top_amount) || 0),
-            )
-            break
+    // 1. 마감 공고 제거
+    if (!props.showExpired) {
+        result = result.filter((item) => {
+            if (!item.application_period) return false
+            const [, endStrRaw] = item.application_period.split('~') || []
+            if (!endStrRaw) return false
+            const endDate = new Date(endStrRaw.trim().replace(/\./g, '-'))
+            return endDate >= today
+        })
     }
 
-    // 2. 필터 - 지역
+    // 2. 지역 필터
     if (appliedFilters.value.regions.length > 0) {
         result = result.filter((item) =>
             appliedFilters.value.regions.some((region) => {
-                const addr = item.hssply_adres || ''
-                const cityMatch = addr.includes(region.city)
+                const city = item.city || ''
+                const district = item.district || ''
+
+                // city 이름 일부만 포함되어도 매칭되도록
+                const cityMatch = city.includes(region.city)
+
                 if (!region.district || region.district === '' || region.district === '__all__') {
                     return cityMatch
                 }
-                return cityMatch && addr.includes(region.district)
+
+                // district 이름도 유연하게 포함 여부 체크
+                return cityMatch && district.includes(region.district)
             }),
         )
     }
 
-    // 3. 필터 - 면적
+    // 3. 면적 필터
     if (appliedFilters.value.squareMeters.length > 0) {
         result = result.filter((item) => {
-            const m2 = Number(item.suply_ar)
-            return appliedFilters.value.squareMeters.some(([min, max]) => m2 >= min && m2 <= max)
-        })
-    }
-
-    // 4. 필터 - 가격
-    if (appliedFilters.value.priceMin !== null || appliedFilters.value.priceMax !== null) {
-        result = result.filter((item) => {
-            const price = (parseFloat(item.lttot_top_amount) || 0) 
-            return (
-                (appliedFilters.value.priceMin === null ||
-                    price >= appliedFilters.value.priceMin) &&
-                (appliedFilters.value.priceMax === null || price <= appliedFilters.value.priceMax)
+            const min = Number(item.min_area) || 0
+            const max = Number(item.max_area) || 0
+            return appliedFilters.value.squareMeters.some(
+                ([rangeMin, rangeMax]) => max >= rangeMin && min <= rangeMax,
             )
         })
     }
 
-    // 5. 그룹화
-    const map = new Map()
-    result.forEach((item) => {
-        const key = item.house_nm
-        const suplyAr = parseFloat(item.suply_ar) || 0
-        const amount = parseFloat(String(item.lttot_top_amount).replace(/,/g, '')) || 0
+    // 4. 가격 필터
+    if (appliedFilters.value.priceMin !== null || appliedFilters.value.priceMax !== null) {
+        result = result.filter((item) => {
+            const minP = parseFloat(item.min_price) || 0
+            const maxP = parseFloat(item.max_price) || 0
+            return (
+                (appliedFilters.value.priceMin === null || maxP >= appliedFilters.value.priceMin) &&
+                (appliedFilters.value.priceMax === null || minP <= appliedFilters.value.priceMax)
+            )
+        })
+    }
 
-        if (!map.has(key)) {
-            map.set(key, {
-                house_nm: item.house_nm,
-                house_type: item.house_type,
-                city: item.city,
-                district: item.district,
-                hssply_adres: item.hssply_adres,
-                start_date: item.application_start_date,
-                end_date: item.application_end_date,
+    // 5. 정렬
+    const parseEndDate = (period) => {
+        if (!period) return new Date(0)
+        const [, endRaw] = period.split('~') || []
+        return new Date((endRaw || '').trim().replace(/\./g, '-'))
+    }
+    const parseStartDate = (period) => {
+        if (!period) return new Date(0)
+        const [startRaw] = period.split('~') || []
+        return new Date((startRaw || '').trim().replace(/\./g, '-'))
+    }
 
-                suply_ar_sum: suplyAr,
-                lttot_top_amount_sum: amount,
-                count: 1,
-            })
-        } else {
-            const obj = map.get(key)
-            // 날짜 업데이트
-            if (item.application_start_date && obj.start_date > item.application_start_date)
-                obj.start_date = item.application_start_date
-            if (item.application_end_date && obj.end_date < item.application_end_date)
-                obj.end_date = item.application_end_date
+    switch (selectedFilter.value) {
+        case 'latest':
+            result.sort(
+                (a, b) =>
+                    parseStartDate(b.application_period) - parseStartDate(a.application_period),
+            )
+            break
+        case 'deadline-first':
+            result.sort(
+                (a, b) => parseEndDate(a.application_period) - parseEndDate(b.application_period),
+            )
+            break
+        case 'recommend':
+            result.sort((a, b) => (parseFloat(b.max_price) || 0) - (parseFloat(a.max_price) || 0))
+            break
+    }
 
-            // 누적
-            obj.suply_ar_sum += suplyAr
-            obj.lttot_top_amount_sum += amount
-            obj.count += 1
-        }
-    })
-
-    // 평균값 계산해서 반환
-    return Array.from(map.values()).map((obj) => {
-        const avgSuplyAr = obj.suply_ar_sum / obj.count
-        const avgAmount = obj.lttot_top_amount_sum / obj.count
-
-        return {
-            ...obj,
-            application_start_date: obj.start_date,
-            application_end_date: obj.end_date,
-            application_period: `${obj.start_date} ~ ${obj.end_date}`,
-            suply_ar: avgSuplyAr.toFixed(0),
-            lttot_top_amount: avgAmount, // 정수화
-        }
-    })
+    return result
 })
-
 // --- 스크롤 / 초기화 ---
 const hasActiveFilters = computed(
     () =>

--- a/src/stores/favorites.js
+++ b/src/stores/favorites.js
@@ -1,42 +1,59 @@
+import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import api from '@/api/axios'
 
-export const useFavoritesStore = defineStore('favorites', {
-    state: () => ({
-        favorites: [], // 즐겨찾기된 공고 리스트
-    }),
-    actions: {
-        async initializeFavorites() {
-            const res = await api.get('/me/favorite')
-            this.favorites = res.data
-        },
+export const useFavoritesStore = defineStore('favorites', () => {
+  // 상태
+  const favorites = ref([])
 
-        async addFavorite({ house_type, pblanc_no }) {
-            try {
-                await api.post('/favorites', { house_type, pblanc_no })
-                this.favorites.push({ house_type, pblanc_no })
-            } catch (err) {
-                console.error('즐겨찾기 추가 실패', err)
-            }
-        },
+  // 즐겨찾기 여부 확인
+  function isFavorite(house_type, pblanc_no) {
+    return favorites.value.some(
+      fav => fav.house_type === house_type && fav.pblanc_no === pblanc_no
+    )
+  }
 
-        async removeFavorite({ house_type, pblanc_no }) {
-            try {
-                await api.delete('/favorites', {
-                    data: { house_type, pblanc_no }, // DELETE도 data 필요
-                })
-                this.favorites = this.favorites.filter(
-                    f => !(f.house_type === house_type && f.pblanc_no === pblanc_no),
-                )
-            } catch (err) {
-                console.error('즐겨찾기 삭제 실패', err)
-            }
-        },
+  // 즐겨찾기 목록 초기화
+  async function initializeFavorites() {
+    try {
+      const res = await api.get('/me/favorite')
+      // 서버 응답이 배열인지 확인하고 세팅
+      favorites.value = Array.isArray(res.data) ? res.data : []
+    } catch (err) {
+      console.error('즐겨찾기 목록 로드 실패', err)
+      favorites.value = [] // 실패 시 빈 배열
+    }
+  }
 
-        isFavorite(house_type, pblanc_no) {
-            return this.favorites.some(
-                f => f.house_type === house_type && f.pblanc_no === pblanc_no,
-            )
-        },
-    },
+  // 즐겨찾기 추가
+  async function addFavorite({ house_type, pblanc_no }) {
+    try {
+      await api.post('/favorites', { house_type, pblanc_no })
+      favorites.value.push({ house_type, pblanc_no })
+    } catch (err) {
+      console.error('즐겨찾기 추가 실패', err)
+    }
+  }
+
+  // 즐겨찾기 삭제
+  async function removeFavorite({ house_type, pblanc_no }) {
+    try {
+      await api.delete('/favorites', {
+        data: { house_type, pblanc_no }, // DELETE 요청에 data 필요
+      })
+      favorites.value = favorites.value.filter(
+        fav => !(fav.house_type === house_type && fav.pblanc_no === pblanc_no)
+      )
+    } catch (err) {
+      console.error('즐겨찾기 삭제 실패', err)
+    }
+  }
+
+  return {
+    favorites,
+    isFavorite,
+    initializeFavorites,
+    addFavorite,
+    removeFavorite,
+  }
 })

--- a/src/stores/favorites.js
+++ b/src/stores/favorites.js
@@ -1,104 +1,42 @@
-// src/stores/favorites.js
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
-import { useUserStore } from './user'
 import api from '@/api/axios'
 
-export const useFavoritesStore = defineStore('favorites', () => {
-    const userStore = useUserStore() // ← 이 줄을 꼭 추가!
-    const favoriteIds = ref(new Set())
+export const useFavoritesStore = defineStore('favorites', {
+    state: () => ({
+        favorites: [], // 즐겨찾기된 공고 리스트
+    }),
+    actions: {
+        async initializeFavorites() {
+            const res = await api.get('/me/favorite')
+            this.favorites = res.data
+        },
 
-    const favoritesCount = computed(() => favoriteIds.value.size)
-    const favoriteIdsList = computed(() => Array.from(favoriteIds.value))
-    const isFavorite = (id) => favoriteIds.value.has(id)
-
-    async function fetchFavoritesFromServer() {
-        const userStore = useUserStore()
-        console.log('userStore.id:', userStore.id)
-        console.log('userStore.id.value:', userStore.id?.value)
-        if (!userStore.isLoggedIn) return
-
-        try {
-            const res = await api.get('/me/favorite/list')
-            const raw = res.data['favorites(즐겨찾기목록)'] || []
-            const ids = raw.map((item) => item.apt_idx ?? item.offi_idx)
-            favoriteIds.value = new Set(ids)
-            localStorage.setItem('favorites', JSON.stringify(ids))
-        } catch (err) {
-            console.error('서버 즐겨찾기 로드 실패:', err)
-        }
-    }
-
-    async function addToFavorites(subscription) {
-        const userStore = useUserStore()
-
-        const payload = {
-            noticeIdx: subscription.id, // 서버 요구사항
-            houseType: subscription.house_type ?? '', // 아파트 / 오피스텔 등
-            usersIdx: userStore.user_id, // 로그인 유저 고유 ID
-        }
-
-        console.log('▶ 즐겨찾기 추가 요청 payload:', payload)
-
-        try {
-            await api.post('/me/favorite', payload)
-            console.log('✅ 서버 즐겨찾기 추가 성공')
-        } catch (err) {
-            const status = err.response?.status
-            const data = err.response?.data
-            console.warn(`🚨 서버 에러(${status}):`, data)
-            if (status !== 400 || !String(data).includes('이미 즐겨찾기')) {
-                throw err
+        async addFavorite({ house_type, pblanc_no }) {
+            try {
+                await api.post('/favorites', { house_type, pblanc_no })
+                this.favorites.push({ house_type, pblanc_no })
+            } catch (err) {
+                console.error('즐겨찾기 추가 실패', err)
             }
-        } finally {
-            await fetchFavoritesFromServer()
-        }
-    }
+        },
 
-    async function removeFromFavorites(id) {
-        if (!favoriteIds.value.has(id)) return
-        try {
-            await api.delete(`/me/favorite/${id}`)
-            favoriteIds.value.delete(id)
-            localStorage.setItem('favorites', JSON.stringify([...favoriteIds.value]))
-        } catch (err) {
-            console.error('서버 즐겨찾기 제거 실패:', err)
-        }
-    }
+        async removeFavorite({ house_type, pblanc_no }) {
+            try {
+                await api.delete('/favorites', {
+                    data: { house_type, pblanc_no }, // DELETE도 data 필요
+                })
+                this.favorites = this.favorites.filter(
+                    f => !(f.house_type === house_type && f.pblanc_no === pblanc_no),
+                )
+            } catch (err) {
+                console.error('즐겨찾기 삭제 실패', err)
+            }
+        },
 
-    async function toggleFavorite(subscription) {
-        const id = subscription.noticeIdx ?? subscription.id // noticeIdx가 없으면 id fallback
-        if (favoriteIds.value.has(id)) {
-            await removeFromFavorites(id)
-            return false
-        } else {
-            await addToFavorites(subscription)
-            return true
-        }
-    }
-
-    async function initializeFavorites() {
-        // 1) 로컬 불러오기
-        const saved = localStorage.getItem('favorites')
-        if (saved) favoriteIds.value = new Set(JSON.parse(saved))
-
-        // 2) 로그인·토큰 체크 후 서버 동기화
-        if (!userStore.isLoggedIn || !userStore.accessToken) {
-            console.log('즐겨찾기 동기화 스킵 (로그인 필요)')
-            return
-        }
-        await fetchFavoritesFromServer()
-    }
-
-    return {
-        favoriteIds,
-        favoritesCount,
-        favoriteIdsList,
-        isFavorite,
-        fetchFavoritesFromServer,
-        addToFavorites,
-        removeFromFavorites,
-        toggleFavorite,
-        initializeFavorites,
-    }
+        isFavorite(house_type, pblanc_no) {
+            return this.favorites.some(
+                f => f.house_type === house_type && f.pblanc_no === pblanc_no,
+            )
+        },
+    },
 })

--- a/src/stores/subscription.js
+++ b/src/stores/subscription.js
@@ -3,39 +3,19 @@ import { defineStore } from 'pinia'
 import api from '@/api/axios'
 
 export const useSubscriptionsStore = defineStore('subscription', () => {
-    const count = ref(0)
-    const doubleCount = computed(() => count.value * 2)
-    function increment() {
-        count.value++
-    }
-
     const subscriptions = ref([])
     const loading = ref(false)
-
-    function parseAddress(addr) {
-        // 예: "경기도 의정부시 가능동 123-45"
-        if (!addr) return { city: '', district: '' }
-        const parts = addr.split(' ')
-        return {
-            city: parts[0] || '',
-            district: parts[1] || '',
-        }
-    }
 
     // 서버에서 청약 공고 불러오기
     async function fetchSubscriptions() {
         loading.value = true
         try {
-            console.log('API 호출 시작') // <-- 추가
+            console.log('API 호출 시작')
             const res = await api.get('/subscriptions')
-            console.log('API 응답:', res) // <-- 추가
+            console.log('API 응답:', res)
 
-            subscriptions.value = res.data.map((item, index) => {
-                console.log('원본 item:', item) // <-- 추가
-                const { city, district } = parseAddress(item.hssply_adres)
-                // 잘됨
-                console.log(parseAddress('경기도 의정부시 가능동 123-45'))
-
+            subscriptions.value = res.data.map((item) => {
+                // application_period 분리
                 let start_date = ''
                 let end_date = ''
                 if (item.application_period) {
@@ -43,23 +23,26 @@ export const useSubscriptionsStore = defineStore('subscription', () => {
                     start_date = parts[0]?.trim()
                     end_date = parts[1]?.trim()
                 }
+
                 return {
-                    id: item.notice_idx ?? item.apt_idx ?? item.offi_idx,
+                    id: item.pblanc_no, // 이제 pblanc_no가 고유 키
+                    pblanc_no: item.pblanc_no,
                     house_nm: item.house_nm,
                     house_type: item.house_type,
-                    city,
-                    district,
+                    city: item.si,
+                    district: item.sigungu,
                     hssply_adres: item.hssply_adres,
+                    application_period: item.application_period,
                     application_start_date: start_date,
                     application_end_date: end_date,
-                    suply_ar: item.suply_ar,
-                    lttot_top_amount: item.lttot_top_amount,
+                    min_area: item.min_area,
+                    max_area: item.max_area,
+                    min_price: item.min_price,
+                    max_price: item.max_price,
                 }
             })
 
-            // 로그 2번 찍기 (Proxy 그대로 vs 실제 배열)
-            console.log('최종 가공된 데이터(Proxy):', subscriptions.value)
-            console.log('toRaw:', JSON.parse(JSON.stringify(subscriptions.value)))
+            console.log('최종 가공된 데이터:', JSON.parse(JSON.stringify(subscriptions.value)))
         } catch (err) {
             console.error('청약 목록 로드 실패:', err)
         } finally {
@@ -68,9 +51,6 @@ export const useSubscriptionsStore = defineStore('subscription', () => {
     }
 
     return {
-        count,
-        doubleCount,
-        increment,
         subscriptions,
         loading,
         fetchSubscriptions,


### PR DESCRIPTION


## ✨ 변경 사항
- 청약 공고 리스트 새로운 구조 api와 다시 연동
- 공고 카드 수정(가격, 평형 평균 --> 최솟값~ 으로 수정)
- 마감된 공고는 '즐겨찾기 한 공고' 에서만 확인 가능하도록 수정

---

## 🧪 테스트 방법
1. 청약 공고 리스트 페이지로 이동
2. 수정된 공고 카드 확인
3. 필터 작동 확인

---

## 🔍 관련 이슈
- #175 (청약 공고 리스트 api 연동)

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
