### PR TITLE
feat: 선호 설정 저장 및 지도 수정

### DIFF
--- a/src/components/home/RecommendSection.vue
+++ b/src/components/home/RecommendSection.vue
@@ -22,6 +22,7 @@
         </div>
       </div> -->
 
+            <!-- 선호 불러오기 api완성되면 정보 넣기! -->
             <SubscriptionCard v-for="item in recommendList" :key="item.id" :subscription="item" />
         </div>
 

--- a/src/components/home/RecommendSection.vue
+++ b/src/components/home/RecommendSection.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="bg-white p-4 rounded-xl border shadow-sm">
-    <div class="flex justify-between items-center mb-3">
-      <h2 class="text-lg font-bold">맞춤형 청약 추천</h2>
-      <Cog class="w-4 h-4 text-gray-500 cursor-pointer" @click="goToPreference" />
-    </div>
+    <div class="bg-white p-4 rounded-xl border shadow-sm">
+        <div class="flex justify-between items-center mb-3">
+            <h2 class="text-lg font-bold">맞춤형 청약 추천</h2>
+            <Cog class="w-4 h-4 text-gray-500 cursor-pointer" @click="goToPreference" />
+        </div>
 
-    <!-- ✅ 선호 설정된 경우 -->
-    <div v-if="recommendList.length > 0" class="space-y-3">
-      <div
+        <!-- ✅ 선호 설정된 경우 -->
+        <div v-if="recommendList.length > 0" class="space-y-3">
+            <!-- <div
         v-for="item in recommendList"
         :key="item.id"
         class="border rounded-lg p-3 flex gap-3 items-center"
@@ -20,47 +20,47 @@
           <p class="font-semibold">{{ item.name }}</p>
           <p class="text-sm text-gray-500">{{ item.location }}</p>
         </div>
-      </div>
-    </div>
+      </div> -->
 
-    <!-- ❌ 선호 설정 안 된 경우 -->
-    <div
-      v-else
-      class="bg-[#FFF7E7] rounded-xl p-4 text-center flex flex-col items-center"
-    >
-      <Settings class="w-10 h-10 text-gray-500 mb-2" />
-      <p class="text-lg font-bold text-gray-800">선호 설정이 필요해요!</p>
-      <p class="text-sm text-gray-500 mt-1 leading-relaxed">
-        선호하는 지역과 평수를 설정하면<br />
-        맞춤형 청약 추천을 받을 수 있어요
-      </p>
+            <SubscriptionCard v-for="item in recommendList" :key="item.id" :subscription="item" />
+        </div>
 
-      <button
-        @click="goToPreference"
-        class="mt-3 w-full bg-[#F2954B] text-white py-2 text-sm rounded flex justify-center items-center gap-1"
-      >
-        <Settings class="w-4 h-4" /> 선호 설정하기
-      </button>
+        <!-- ❌ 선호 설정 안 된 경우 -->
+        <div v-else class="bg-[#FFF7E7] rounded-xl p-4 text-center flex flex-col items-center">
+            <Settings class="w-10 h-10 text-gray-500 mb-2" />
+            <p class="text-lg font-bold text-gray-800">선호 설정이 필요해요!</p>
+            <p class="text-sm text-gray-500 mt-1 leading-relaxed">
+                선호하는 지역과 평수를 설정하면<br />
+                맞춤형 청약 추천을 받을 수 있어요
+            </p>
+
+            <button
+                @click="goToPreference"
+                class="mt-3 w-full bg-[#F2954B] text-white py-2 text-sm rounded flex justify-center items-center gap-1"
+            >
+                <Settings class="w-4 h-4" /> 선호 설정하기
+            </button>
+        </div>
     </div>
-  </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Cog, Settings } from 'lucide-vue-next'
+import SubscriptionCard from '../subscription/SubscriptionCard.vue'
 
 const router = useRouter()
- 
+
 const props = defineProps({
-  isPreferenceSet: Boolean,
-  recommendList: {
-    type: Array,
-    default: () => [],
-  },
+    isPreferenceSet: Boolean,
+    recommendList: {
+        type: Array,
+        default: () => [],
+    },
 })
 
 const goToPreference = () => {
-  router.push('/preference')
+    router.push('/preference')
 }
 </script>

--- a/src/components/subscription/SubscriptionCard.vue
+++ b/src/components/subscription/SubscriptionCard.vue
@@ -188,14 +188,14 @@ const handleFavoriteClick = () => {
     }
 }
 
-// 아파트와 기타 주택 디테일 페이지 분리
+
 const handleDetailClick = () => {
-    const { pblanc_no, house_type } = props.subscription
-    if (house_type === 'APT') {
-        router.push(`/subscriptions/${pblanc_no}`)
-    } else {
-        router.push(`/etcsubscriptions/${pblanc_no}`)
-    }
+  const { pblanc_no, house_type } = props.subscription
+  if (house_type === 'APT' || house_type === '신혼희망타운') {
+    router.push(`/subscriptions/${pblanc_no}`)
+  } else {
+    router.push(`/etcsubscriptions/${pblanc_no}`)
+  }
 }
 
 const formatToNum = (strValue) => {

--- a/src/pages/map/Map.vue
+++ b/src/pages/map/Map.vue
@@ -107,38 +107,44 @@ import BottomNavbar from '@/components/common/BottomNavbar.vue'
 import SubscriptionCard from '@/components/subscription/SubscriptionCard.vue'
 import { districts } from '@/data/districts'
 import { ListFilter, CircleAlert } from 'lucide-vue-next'
+import api from '@/api/axios'
 
-// 더미 청약 데이터
-const dummyList = [
-    {
-        id: 1,
-        title: '힐스테이트 청약',
-        lat: 37.5658,
-        lng: 126.978,
-        city: '서울시',
-        district: '강남구',
-        applicationStartDate: '2025.08.10',
-        applicationCompleteDate: '2025.08.12',
-        squareMeters: 104,
-        price: '800000000',
-        type: '아파트',
-        isFavorite: false,
-    },
-    {
-        id: 2,
-        title: '자이 청약',
-        lat: 37.57,
-        lng: 126.982,
-        city: '서울시',
-        district: '마포구',
-        applicationStartDate: '2025.09.01',
-        applicationCompleteDate: '2025.09.05',
-        squareMeters: 84,
-        price: '600000000',
-        type: '아파트',
-        isFavorite: true,
-    },
-]
+const subscriptionList = ref([])
+const coordsCache = {}
+
+onMounted(async () => {
+    const kakao = await loadKakaoMapScript()
+    map.value = new kakao.maps.Map(mapRef.value, {
+        center: new kakao.maps.LatLng(37.5665, 126.978),
+        level: 6,
+    })
+
+    const res = await api.get('/subscriptions')
+    subscriptionList.value = res.data
+
+    // 좌표를 먼저 준비 (한 번만)
+    await prepareCoords(subscriptionList.value)
+
+    await centerMapToTopCity(subscriptionList.value, map.value)
+
+    let idleTimer = null
+    kakao.maps.event.addListener(map.value, 'idle', () => {
+        if (idleTimer) clearTimeout(idleTimer)
+        idleTimer = setTimeout(() => {
+            const bounds = map.value.getBounds()
+            const visible = subscriptionList.value.filter((item) => {
+                const addr = `${item.si} ${item.sigungu}`
+                const coords = coordsCache[addr]
+                if (coords) {
+                    const pos = new kakao.maps.LatLng(coords.lat, coords.lng)
+                    return bounds.contains(pos)
+                }
+                return false // 좌표 없는 건 다음에 찍히게
+            })
+            renderMarkers(visible)
+        }, 500)
+    })
+})
 
 const mapRef = ref(null)
 const map = ref(null)
@@ -154,6 +160,70 @@ const selectedDistrict = ref('')
 
 const cities = Object.keys(districts)
 const filteredDistricts = computed(() => districts[selectedCity.value] || [])
+
+function getCoordsForAddress(addr, callback) {
+    // 캐시에 있으면 바로 사용
+    if (coordsCache[addr]) {
+        callback(coordsCache[addr])
+        return
+    }
+
+    const geocoder = new kakao.maps.services.Geocoder()
+    geocoder.addressSearch(addr, (result, status) => {
+        if (status === kakao.maps.services.Status.OK) {
+            const lat = parseFloat(result[0].y)
+            const lng = parseFloat(result[0].x)
+            coordsCache[addr] = { lat, lng }
+            callback({ lat, lng })
+        }
+    })
+}
+
+// 청약 많은 시/도 찾기
+function getTopCity(list) {
+    const countMap = {}
+
+    list.forEach((item) => {
+        const city = item.si
+        countMap[city] = (countMap[city] || 0) + 1
+    })
+
+    let maxCount = 0
+    let topCity = null
+    for (const city in countMap) {
+        if (countMap[city] > maxCount) {
+            maxCount = countMap[city]
+            topCity = city
+        }
+    }
+
+    // 디버깅 출력
+    console.log('청약 공고 수:', countMap)
+    console.log(`가장 많은 청약 공고가 있는 시/도: ${topCity} (${maxCount}개)`)
+
+    return topCity // 예: "서울특별시"
+}
+
+// 청약 많은 시/도를 중심으로
+async function centerMapToTopCity(list, map) {
+    const topCity = getTopCity(list)
+    if (!topCity) return
+
+    // topCity 공고만 출력
+    const topCityItems = list.filter((item) => item.si === topCity)
+    console.log(`"${topCity}" 공고 목록:`, topCityItems)
+
+    const geocoder = new kakao.maps.services.Geocoder()
+    geocoder.addressSearch(topCity, (result, status) => {
+        if (status === kakao.maps.services.Status.OK) {
+            const coords = new kakao.maps.LatLng(result[0].y, result[0].x)
+            map.setCenter(coords)
+
+            // 초기에는 topCity만 마커 찍기
+            renderMarkers(topCityItems)
+        }
+    })
+}
 
 // 필터 적용 버튼 클릭 시 동작
 const applyFilters = async () => {
@@ -194,38 +264,56 @@ const mapHeightStyle = computed(() => {
     }
 })
 
-onMounted(async () => {
-    const kakao = await loadKakaoMapScript()
-
-    map.value = new kakao.maps.Map(mapRef.value, {
-        center: new kakao.maps.LatLng(37.5665, 126.978),
-        level: 6,
-    })
-
-    renderMarkers()
-})
-
-// 마커 렌더링
-const renderMarkers = () => {
+function renderMarkers(list) {
     const kakao = window.kakao
     markers.value.forEach((marker) => marker.setMap(null))
     markers.value = []
 
-    const filtered =
-        activeTab.value === 'favorite' ? dummyList.filter((item) => item.isFavorite) : dummyList
+    list.forEach((item) => {
+        const addr = `${item.si} ${item.sigungu}`
+        const coords = coordsCache[addr]
+        if (!coords) return // 좌표 없는 건 스킵
 
-    filtered.forEach((item) => {
-        const marker = new kakao.maps.Marker({
-            position: new kakao.maps.LatLng(item.lat, item.lng),
-            map: map.value,
-        })
+        const position = new kakao.maps.LatLng(coords.lat, coords.lng)
+        if (!map.value.getBounds().contains(position)) return
 
+        const marker = new kakao.maps.Marker({ position, map: map.value })
         kakao.maps.event.addListener(marker, 'click', () => {
             selectedItem.value = item
         })
-
         markers.value.push(marker)
     })
+}
+
+function addMarkerIfInBounds(item, lat, lng) {
+    const kakao = window.kakao
+    const position = new kakao.maps.LatLng(lat, lng)
+    if (!map.value.getBounds().contains(position)) return
+
+    const marker = new kakao.maps.Marker({ position, map: map.value })
+    kakao.maps.event.addListener(marker, 'click', () => {
+        selectedItem.value = item
+    })
+    markers.value.push(marker)
+}
+
+async function prepareCoords(list) {
+    const geocoder = new kakao.maps.services.Geocoder()
+    for (const item of list) {
+        const addr = `${item.si} ${item.sigungu}`
+        if (!coordsCache[addr]) {
+            await new Promise((resolve) => {
+                geocoder.addressSearch(addr, (result, status) => {
+                    if (status === kakao.maps.services.Status.OK) {
+                        const lat = parseFloat(result[0].y)
+                        const lng = parseFloat(result[0].x)
+                        coordsCache[addr] = { lat, lng }
+                    }
+                    resolve()
+                })
+            })
+        }
+    }
 }
 
 // 즐겨찾기 toggle

--- a/src/pages/subscription/SubscriptionDetail.vue
+++ b/src/pages/subscription/SubscriptionDetail.vue
@@ -25,9 +25,8 @@
                         />
                     </button>
                 </div>
-                <p class="text-sm text-gray-500">
-                    아파트 · {{ areaList }} · {{ subscription.householdCount }}세대
-                </p>
+                <p class="text-sm text-gray-500">아파트· {{ subscription.householdCount }}세대</p>
+                <p class="text-sm text-gray-500">{{ areaList }}</p>
                 <p class="mt-1 text-sm text-gray-500">
                     <MapPin class="inline mr-1" :size="16" />{{ subscription.address }}
                 </p>
@@ -41,7 +40,7 @@
                     }}
                 </p>
                 <p class="mt-2 text-lg font-bold text-blue-600">
-                    {{ formatToEok(subscription.price) }}
+                    {{ formatToEok(subscription.min_price) }} ~ {{ formatToEok(subscription.max_price) }}
                 </p>
 
                 <!-- 지도 영역 -->
@@ -244,13 +243,28 @@ onMounted(async () => {
             if (d[key]) d[key] = formatDate(d[key])
         })
 
+        // ---- 가격 범위 계산 ----
+        let minPrice = null
+        let maxPrice = null
+
+        if (Array.isArray(d.apt_type)) {
+            const prices = d.apt_type
+                .map((t) => parseFloat(t.LTTOT_TOP_AMOUNT))
+                .filter((v) => !isNaN(v))
+            if (prices.length > 0) {
+                minPrice = Math.min(...prices)
+                maxPrice = Math.max(...prices)
+            }
+        }
+
         // subscription 객체 구성
         subscription.value = {
             ...d,
             house_nm: d.house_nm,
             type: d.house_secd_nm,
             address: d.hssply_adres,
-            price: d.apt_type?.[0]?.LTTOT_TOP_AMOUNT ? d.apt_type[0].LTTOT_TOP_AMOUNT : '',
+            min_price: minPrice,
+            max_price: maxPrice,
             householdCount: d.tot_suply_hshldco,
             favorite_count: d.favorite_count,
             view_count: d.view_count,
@@ -311,21 +325,35 @@ const handleFavoriteClick = () => {
     favoritesStore.toggleFavorite(subscription.value.houseSecdNm, subscription.value.pblancNo)
 }
 
+// 면적 최소 ~ 최대로 보여주는 함수
+// const areaList = computed(() => {
+//     const types = subscription.value?.apt_type || subscription.value?.officetel_type
+//     if (!types || types.length === 0) return ''
+
+//     // 면적만 추출
+//     const areas = types.map((t) => parseFloat(t.SUPLY_AR || t.EXCLUSE_AR)).filter((a) => !isNaN(a))
+//     if (areas.length === 0) return ''
+
+//     const min = Math.min(...areas)
+//     const max = Math.max(...areas)
+
+//     // 최소 = 최대라면 하나만, 아니면 범위 표기
+//     return min === max ? `${min.toFixed(1)}㎡` : `${min.toFixed(1)}㎡ ~ ${max.toFixed(1)}㎡`
+
+// })
+
 const areaList = computed(() => {
-  const types = subscription.value?.apt_type || subscription.value?.officetel_type
-  if (!types || types.length === 0) return ''
+    const types = subscription.value?.apt_type || subscription.value?.officetel_type
+    if (!types || types.length === 0) return ''
 
-  // 면적만 추출
-  const areas = types.map(t => parseFloat(t.SUPLY_AR || t.EXCLUSE_AR)).filter(a => !isNaN(a))
-  if (areas.length === 0) return ''
-
-  const min = Math.min(...areas)
-  const max = Math.max(...areas)
-
-  // 최소 = 최대라면 하나만, 아니면 범위 표기
-  return min === max
-    ? `${min.toFixed(1)}㎡`
-    : `${min.toFixed(1)}㎡ ~ ${max.toFixed(1)}㎡`
+    return types
+        .map((t) => {
+            // 아파트는 SUPLY_AR, 오피스텔은 EXCLUSE_AR 사용
+            const area = parseFloat(t.SUPLY_AR || t.EXCLUSE_AR)
+            return isNaN(area) ? null : `${area.toFixed(1)}㎡`
+        })
+        .filter(Boolean) // null 제거
+        .join(' / ')
 })
 
 function calcBadge(start, end) {
@@ -473,7 +501,10 @@ function getAddressUpToRi(addr) {
 // }
 
 function goToApply() {
-    window.open('https://www.applyhome.co.kr/ap/aph/reqst/selectSubscrtReqstAptMainView.do', '_blank')
+    window.open(
+        'https://www.applyhome.co.kr/ap/aph/reqst/selectSubscrtReqstAptMainView.do',
+        '_blank',
+    )
 }
 
 function viewSubscriptionInfo() {

--- a/src/pages/subscription/SubscriptionDetail.vue
+++ b/src/pages/subscription/SubscriptionDetail.vue
@@ -25,7 +25,7 @@
                         />
                     </button>
                 </div>
-                <p class="text-sm text-gray-500">아파트· {{ subscription.householdCount }}세대</p>
+                <p class="text-sm text-gray-500">아파트 · {{ subscription.householdCount }}세대</p>
                 <p class="text-sm text-gray-500">{{ areaList }}</p>
                 <p class="mt-1 text-sm text-gray-500">
                     <MapPin class="inline mr-1" :size="16" />{{ subscription.address }}


### PR DESCRIPTION

## ✨ 변경 사항
- 사용자 선호 설정 저장까지 완료
- 지도 수정 - 초기 화면에서 서울 지역 청약만 마커 표시)

---

## 🧪 테스트 방법
1. 선호 설정 페이지 접속
2. 선호 설정 저장 확인
3. 지도 - 확인 보류(요청 제한)

---

## 🔍 관련 이슈
- #135 (선호 설정 페이지)
- #201 (지도 api 연동)

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
