### PR TITLE
remove_pinia_store_after_logout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,13 +2,16 @@
     <div class="min-h-screen bg-white relative">
         <ModalBase class="border border-black" />
         <RouterView />
-        <InstallPrompt/>
+        <InstallPrompt />
     </div>
 </template>
 
 <script setup>
 import { RouterView } from 'vue-router'
 import { useAccountStore } from '@/stores/account'
+import { useScoreStore } from '@/stores/scoreStore'
+import { useUserStore } from '@/stores/user'
+import scoreApi from '@/api/scoreApi'
 import { onMounted } from 'vue'
 import InstallPrompt from '@/components/common/InstallPrompt.vue'
 import ModalBase from './components/modal/ModalBase.vue'
@@ -16,5 +19,16 @@ import ModalBase from './components/modal/ModalBase.vue'
 onMounted(async () => {
     const accountStore = useAccountStore()
     await accountStore.fetchAccount()
+    const userStore = useUserStore()
+    const scoreStore = useScoreStore()
+
+    if (userStore.isLoggedIn) {
+        try {
+            const res = await scoreApi.getLastScore()
+            scoreStore.setScore(res.data)
+        } catch (err) {
+            console.warn('[초기 가점 정보 로딩 실패]', err)
+        }
+    }
 })
 </script>

--- a/src/pages/auth/Login.vue
+++ b/src/pages/auth/Login.vue
@@ -104,14 +104,12 @@ async function handleLogin() {
             accountStore.setAccount(res2.data)
         } catch (err) {
             console.error(err)
-            alert('계좌 정보 불러오기에 실패했습니다.')
         }
         try {
             const res2 = await accountApi.fetch()
             accountStore.setAccount(res2.data)
         } catch (err) {
             console.error(err)
-            alert('계좌 정보 불러오기에 실패했습니다.')
         }
 
         // ✅ ③ 가점 점수 정보도 불러오기
@@ -120,7 +118,6 @@ async function handleLogin() {
             scoreStore.setScore(res3.data)
         } catch (err) {
             console.error(err)
-            alert('가점 정보 불러오기에 실패했습니다.')
         }
 
         // ④ 홈으로 이동

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -2,6 +2,8 @@
 import { defineStore } from 'pinia'
 import authApi from '@/api/authApi'
 import api from '@/api/axios'
+import { useAccountStore } from '@/stores/account'
+import { useScoreStore } from '@/stores/scoreStore'
 
 export const useUserStore = defineStore('user', {
     state: () => {
@@ -66,10 +68,56 @@ export const useUserStore = defineStore('user', {
             try {
                 await authApi.logout()
             } catch {}
+
+            // ✅ 모든 store 초기화
             this.$reset()
+
+            // ✅ 로컬스토리지 삭제
             localStorage.removeItem('accessToken')
             localStorage.removeItem('refreshToken')
             localStorage.removeItem('user')
+
+            // ✅ account 관련 로컬스토리지 삭제
+            localStorage.removeItem('accountData')
+            localStorage.removeItem('accountStore') // 은행 선택 정보
+            localStorage.removeItem('residence') // 선호 지역 정보
+
+            // ✅ score 관련 로컬스토리지 삭제
+            localStorage.removeItem('headOfHousehold')
+            localStorage.removeItem('houseOwner')
+            localStorage.removeItem('houseDisposal')
+            localStorage.removeItem('disposalDate')
+            localStorage.removeItem('maritalStatus')
+            localStorage.removeItem('weddingDate')
+            localStorage.removeItem('dependentsNm')
+            localStorage.removeItem('residenceStartDate')
+            localStorage.removeItem('noHousePeriod')
+
+            // ✅ 다른 store도 상태 초기화
+            const accountStore = useAccountStore()
+            accountStore.reset()
+            accountStore.$reset() // ✅ Pinia 자체 상태 초기화
+
+            const scoreStore = useScoreStore()
+            // scoreStore.result = {
+            //     head_of_household: 0,
+            //     house_owner: 0,
+            //     house_disposal: 0,
+            //     disposal_date: null,
+            //     marital_status: 0,
+            //     wedding_date: null,
+            //     dependents_nm: 0,
+            //     no_house_period: 0,
+            //     residence_start_date: '',
+            //     payment_period: 0,
+            //     dependents_score: 0,
+            //     no_house_score: 0,
+            //     payment_period_score: 0,
+            //     total_ga_score: 0,
+            // }
+            scoreStore.isCalculated = false
+            scoreStore.$reset() // ✅ Pinia 자체 상태 초기화
+            // ✅ axios header 정리
             delete api.defaults.headers.common.Authorization
         },
 


### PR DESCRIPTION
## 📌 PR 제목 예시
refactor: 로그아웃하면 쿠키, 로컬스토리지, 피니아스토어 모두 제거

---

## ✨ 변경 사항
- 로그아웃하면 쿠키, 로컬스토리지, 피니아스토어 모두 제거

---

## 🧪 테스트 방법
1. `로그인하고 계좌 연결, 가점 정보 계산해본 후, 로그아웃하고, 다른 계정 로그인해서 이전 계좌 내용 안나오는지 확인, 그리고 다시 로그아웃 후 원래 게정으로 로그인해서 계좌, 가점 정보 잘 나오는지 확인

---

## 🔍 관련 이슈

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
