### PR TITLE
feat: 청약 주변 인프라 표시 기능 추가#201

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "kb-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^7.0.0",
+        "@fortawesome/free-solid-svg-icons": "^7.0.0",
         "@fullcalendar/core": "^6.1.18",
         "@fullcalendar/daygrid": "^6.1.18",
         "@fullcalendar/interaction": "^6.1.18",
@@ -2765,6 +2767,39 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.4.tgz",
       "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.0.tgz",
+      "integrity": "sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
+      "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-njSLAllkOddYDCXgTFboXn54Oe5FcvpkWq+FoetOHR64PbN0608kM02Lze0xtISGpXgP+i26VyXRQA0Irh3Obw==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@fullcalendar/core": {
       "version": "6.1.18",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.0.0",
+    "@fortawesome/free-solid-svg-icons": "^7.0.0",
     "@fullcalendar/core": "^6.1.18",
     "@fullcalendar/daygrid": "^6.1.18",
     "@fullcalendar/interaction": "^6.1.18",

--- a/src/components/modal/SubscriptionFilterModal.vue
+++ b/src/components/modal/SubscriptionFilterModal.vue
@@ -60,24 +60,20 @@
                 <button
                     v-for="option in areaOptions"
                     :key="option.value"
-                    @click="toggleArea(option.value)"
+                    @click="selectArea(option.value)"
                     :class="[
                         'px-3 py-2 rounded-full border',
-                        selectedAreas.some((a) => a.toString() === option.value.toString())
+                        props.selectedArea?.toString() === option.value.toString()
                             ? 'bg-blue-500 text-white'
                             : 'bg-white text-gray-600',
                     ]"
                 >
                     {{ option.label }}
-
-                    <!-- {{ option.label }}<br> ({{ option.pyeong }}) -->
                 </button>
             </div>
 
             <!-- 가격 -->
-            <label class="text-sm font-semibold text-gray-800 block mb-2"
-                >가격대 (만원 단위)</label
-            >
+            <label class="text-sm font-semibold text-gray-800 block mb-2">가격대 (만원 단위)</label>
             <div class="flex items-center gap-2 mb-6">
                 <input
                     :value="priceMin"
@@ -107,14 +103,14 @@
 </template>
 
 <script setup>
-import { computed, defineProps, defineEmits } from 'vue'
+import { ref, computed, defineProps, defineEmits } from 'vue'
 import { districts } from '@/data/districts'
 import { areaOptions } from '@/data/area'
 
 const props = defineProps({
     visible: Boolean,
     selectedRegions: Array,
-    selectedAreas: Array,
+    selectedArea: { type: Array, default: null }, // ✅ 배열 허용
     priceMin: Number,
     priceMax: Number,
     selectedCity: String,
@@ -127,6 +123,7 @@ const close = () => emit('update:visible', false)
 
 const cities = Object.keys(districts)
 const filteredDistricts = computed(() => districts[props.selectedCity] || [])
+const selectedArea = ref('')
 
 const addSelectedRegion = () => {
     console.log('📍 city:', props.selectedCity, 'district:', props.selectedDistrict)
@@ -154,16 +151,6 @@ const addSelectedRegion = () => {
     emit('update', { field: 'selectedDistrict', value: '' })
 }
 
-// const handleDistrictChange = (e) => {
-//   const district = e.target.value
-//   emit('update', { field: 'selectedDistrict', value: district })
-
-//   // 약간의 지연 후 호출
-//   setTimeout(() => {
-//     addSelectedRegion()
-//   }, 0)
-// }
-
 const handleDistrictChange = (e) => {
     const district = e.target.value
     emit('update', { field: 'selectedDistrict', value: district })
@@ -190,19 +177,6 @@ const handleDistrictChange = (e) => {
     }, 0)
 }
 
-// const onChangeCity = (e) => {
-//     emit('update', { field: 'selectedCity', value: e.target.value })
-
-//     // 약간의 지연 후 호출
-//     setTimeout(() => {
-//         addSelectedRegion()
-//     }, 0)
-// }
-
-// const onChangeRegion = (e) => {
-//     emit('update', { field: 'selectedRegion', value: e.target.value })
-// }
-
 const removeSelectedRegion = (index) => {
     const updated = [...props.selectedRegions]
     updated.splice(index, 1)
@@ -216,6 +190,11 @@ const toggleArea = (val) => {
         ? props.selectedAreas.filter((a) => a.toString() !== valStr)
         : [...props.selectedAreas, [...val]] // 깊은 복사
     emit('update', { field: 'selectedAreas', value: updated })
+}
+
+const selectArea = (val) => {
+    const isSame = JSON.stringify(props.selectedArea) === JSON.stringify(val)
+    emit('update', { field: 'selectedArea', value: isSame ? null : val })
 }
 
 const apply = () => {

--- a/src/pages/subscription/SubscriptionDetail.vue
+++ b/src/pages/subscription/SubscriptionDetail.vue
@@ -369,7 +369,7 @@ const areaList = computed(() => {
     if (!types || types.length === 0) return ''
 
     // 면적만 추출
-    const areas = types.map((t) => parseFloat(t.SUPLY_AR || t.EXCLUSE_AR)).filter((a) => !isNaN(a))
+    const areas = types.map((t) => parseFloat(t.HOUSE_TY || t.EXCLUSE_AR)).filter((a) => !isNaN(a))
     if (areas.length === 0) return ''
 
     const min = Math.min(...areas)

--- a/src/pages/subscription/SubscriptionList.vue
+++ b/src/pages/subscription/SubscriptionList.vue
@@ -79,12 +79,17 @@
             </span>
 
             <!-- 평수 필터 -->
-            <span v-for="(range, index) in appliedFilters.squareMeters" :key="'area-' + index">
+            <div v-if="appliedFilters.squareMeters" class="flex flex-wrap gap-2">
                 <div class="flex items-center bg-green-100 text-green-700 px-2 py-1 rounded-full">
-                    <span>{{ range[0] }}~{{ range[1] }}㎡</span>
-                    <button class="ml-1 font-bold" @click="removeFilter('area', index)">✕</button>
+                    <span>
+                        {{ appliedFilters.squareMeters[0] }}㎡ ~
+                        {{ appliedFilters.squareMeters[1] }}㎡
+                        <!-- (선택) 평 단위도 함께 표시하려면 아래 주석 해제 -->
+                        <!-- · {{ toPyeong(appliedFilters.squareMeters).join(' ~ ') }}평 -->
+                    </span>
+                    <button class="ml-1 font-bold" @click="removeFilter('area')">✕</button>
                 </div>
-            </span>
+            </div>
 
             <!-- 가격 필터 -->
             <div
@@ -94,7 +99,7 @@
                 <span>
                     {{ appliedFilters.priceMin ? formatToEok(appliedFilters.priceMin) + '원' : '' }}
                     ~
-                    {{ appliedFilters.priceMax ? formatToEok(appliedFilters.priceMax)+ '원' : '' }}
+                    {{ appliedFilters.priceMax ? formatToEok(appliedFilters.priceMax) + '원' : '' }}
                 </span>
                 <button class="ml-1 font-bold" @click="removeFilter('price')">✕</button>
             </div>
@@ -104,7 +109,7 @@
         <SubscriptionFilterModal
             :visible="isFilterOpen"
             :selectedRegions="selectedRegions"
-            :selectedAreas="selectedAreas"
+            :selectedArea="selectedArea"
             :priceMin="priceMin"
             :priceMax="priceMax"
             :selectedCity="selectedCity"
@@ -171,11 +176,11 @@ const showSortMenu = ref(false)
 
 const appliedFilters = ref({
     regions: [],
-    squareMeters: [],
+    squareMeters: null,
     priceMin: null,
     priceMax: null,
 })
-const selectedAreas = ref([])
+const selectedArea = ref(null)
 
 const props = defineProps({
     showExpired: { type: Boolean, default: false }, // 기본은 false
@@ -197,7 +202,9 @@ const toggleFilter = () => {
     if (!isFilterOpen.value) {
         // 기존 값 유지
         selectedRegions.value = [...appliedFilters.value.regions]
-        selectedAreas.value = [...appliedFilters.value.squareMeters]
+        selectedArea.value = appliedFilters.value.squareMeters
+            ? [...appliedFilters.value.squareMeters]
+            : null
         priceMin.value = appliedFilters.value.priceMin
         priceMax.value = appliedFilters.value.priceMax
         selectedCity.value = ''
@@ -206,42 +213,68 @@ const toggleFilter = () => {
     isFilterOpen.value = !isFilterOpen.value
 }
 const handleFilterUpdate = ({ field, value }) => {
-    if (field === 'selectedCity') selectedCity.value = value
-    else if (field === 'selectedDistrict') selectedDistrict.value = value
-    else if (field === 'selectedRegions') selectedRegions.value = value
-    else if (field === 'selectedAreas') selectedAreas.value = value
-    else if (field === 'priceMin') priceMin.value = value
-    else if (field === 'priceMax') priceMax.value = value
+  if (field === 'selectedCity') {
+    selectedCity.value = value
+  } else if (field === 'selectedDistrict') {
+    selectedDistrict.value = value
+  } else if (field === 'selectedRegions') {
+    selectedRegions.value = value
+  } else if (field === 'selectedArea') {
+    // ✅ null 또는 [min, max]로 강제 변환
+    if (Array.isArray(value) && value.length === 2) {
+      selectedArea.value = value.map(Number)
+    } else {
+      selectedArea.value = null
+    }
+  } else if (field === 'priceMin') {
+    priceMin.value = value
+  } else if (field === 'priceMax') {
+    priceMax.value = value
+  }
 }
 const removeFilter = (type, index) => {
     if (type === 'region') appliedFilters.value.regions.splice(index, 1)
-    else if (type === 'area') appliedFilters.value.squareMeters.splice(index, 1)
-    else if (type === 'price') {
+    else if (type === 'area') {
+        appliedFilters.value.squareMeters = null // ✅ 단일 범위이므로 null로 해제
+        selectedArea.value = null
+    } else if (type === 'price') {
         appliedFilters.value.priceMin = null
         appliedFilters.value.priceMax = null
     }
 }
+// ✅ helper: 단일 선택된 평수 값을 [min, max] 배열로 정규화
+const normalizeAreaRange = (val) => {
+    if (!val) return null // '', null, undefined => 해제
+    if (Array.isArray(val)) return val.map(Number) // [10,20]
+    if (typeof val === 'string') {
+        const arr = val
+            .split(',')
+            .map((s) => Number(s.trim()))
+            .filter((n) => !Number.isNaN(n))
+        return arr.length ? arr : null // '10,20'
+    }
+    return null
+}
 
-// 필터 적용 부분
+// ✅ 필터 적용
 const applyFilters = () => {
-    const parsedAreas = selectedAreas.value.map((val) =>
-        typeof val === 'string' ? val.split(',').map(Number) : val,
-    )
+    const v = selectedArea.value
+    const normalized = Array.isArray(v) && v.length === 2 ? v.map(Number) : null
     appliedFilters.value = {
-        regions: selectedRegions.value.map((r) => {
-            if (typeof r === 'string') {
-                const [city, district] = r.split(' ')
-                return { city, district: district || '__all__' }
-            }
-            return r
-        }),
-        squareMeters: parsedAreas,
-        priceMin: priceMin.value,
-        priceMax: priceMax.value,
+        regions: selectedRegions.value.map((r) =>
+            typeof r === 'string'
+                ? (() => {
+                      const [city, district] = r.split(' ')
+                      return { city, district: district || '__all__' }
+                  })()
+                : r,
+        ),
+        squareMeters: normalized, // ✅ 항상 null 또는 [min,max]
+        priceMin: priceMin.value ?? null,
+        priceMax: priceMax.value ?? null,
     }
     isFilterOpen.value = false
 }
-
 // --- 최종 목록 계산 ---
 const finalSubscriptions = computed(() => {
     if (!subscriptionsStore.subscriptions || subscriptionsStore.subscriptions.length === 0)
@@ -290,14 +323,17 @@ const finalSubscriptions = computed(() => {
         )
     }
 
-    // 3. 면적 필터
-    if (appliedFilters.value.squareMeters.length > 0) {
+    // 3. 면적 필터 (수정)
+    const range = appliedFilters.value.squareMeters
+
+    if (Array.isArray(range) && range.length === 2) {
+        const [rangeMin, rangeMax] = range.map(Number)
+
         result = result.filter((item) => {
             const min = Number(item.min_area) || 0
             const max = Number(item.max_area) || 0
-            return appliedFilters.value.squareMeters.some(
-                ([rangeMin, rangeMax]) => max >= rangeMin && min <= rangeMax,
-            )
+            // 공고의 [min, max]가 선택 범위와 겹치면 통과
+            return max >= rangeMin && min <= rangeMax
         })
     }
 
@@ -368,7 +404,8 @@ const formatToEok = (priceValue) => {
 const hasActiveFilters = computed(
     () =>
         appliedFilters.value.regions.length > 0 ||
-        appliedFilters.value.squareMeters.length > 0 ||
+        (Array.isArray(appliedFilters.value.squareMeters) &&
+            appliedFilters.value.squareMeters.length === 2) || // ✅
         appliedFilters.value.priceMin !== null ||
         appliedFilters.value.priceMax !== null,
 )


### PR DESCRIPTION


## ✨ 변경 사항
- 청약 공고 디테일 페이지에서 해당 청약 공고의 인프라 지도에 찍기 완료(초안)

---

## 🧪 테스트 방법
1. 청약 공고 디테일 페이지 접속
2. 지도의 청약 주변 인프라 핀 찍히는지 확인

---

## 🔍 관련 이슈
- #201  (지도 api 연동)

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
