### PR TITLE
비밀번호 보기 안보기 추가

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -41,7 +41,7 @@ export default {
     },
     // 로그아웃
     async logout() {
-        return api.post('/auth/logout')
+        return api.delete('/auth/logout')
     },
     // 회원탈퇴
     async signout() {

--- a/src/pages/auth/Login.vue
+++ b/src/pages/auth/Login.vue
@@ -142,7 +142,7 @@ async function handleKakaoLogin() {
     try {
         // ① 카카오 로그인 페이지로 리디렉션해서 code 받기
         const clientId = '53da207a5cc86b7ec03890c960d2937b' // 실제 REST API 키로 교체
-        const redirectUri = 'http://localhost:5173/kakao/callback' // 프론트엔드 콜백 URL
+        const redirectUri = 'https://zibi.vercel.app/kakao/callback' // 프론트엔드 콜백 URL
         const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`
 
         window.location.href = kakaoAuthUrl

--- a/src/pages/auth/Login.vue
+++ b/src/pages/auth/Login.vue
@@ -19,12 +19,23 @@
                 </div>
                 <div>
                     <label class="text-xs text-[#8D8D9] mb-1 block">비밀번호</label>
-                    <input
-                        v-model="password"
-                        type="password"
-                        placeholder="비밀번호를 입력해 주세요."
-                        class="w-full border-b border-[#D9D9D9] py-2 text-sm placeholder-[#C4C4C4] focus:outline-none focus:border-black"
-                    />
+                    <div class="relative">
+                        <input
+                            v-model="password"
+                            :type="showPassword ? 'text' : 'password'"
+                            placeholder="비밀번호를 입력해 주세요."
+                            class="w-full border-b border-[#D9D9D9] py-2 pr-8 text-sm placeholder-[#C4C4C4] focus:outline-none focus:border-black"
+                        />
+                        <!-- Lucide 아이콘: Eye / EyeOff -->
+                        <button
+                            type="button"
+                            @click="togglePassword"
+                            class="absolute right-0 top-1/2 -translate-y-1/2 pr-2 text-gray-500 hover:text-black"
+                        >
+                            <Eye v-if="!showPassword" class="w-5 h-5" />
+                            <EyeOff v-else class="w-5 h-5" />
+                        </button>
+                    </div>
                 </div>
 
                 <PrimaryButton
@@ -66,15 +77,21 @@ import alarmApi from '@/api/alarmApi'
 import { useUserStore } from '@/stores/user'
 import { useAccountStore } from '@/stores/account'
 import { useScoreStore } from '@/stores/scoreStore'
+import { Eye, EyeOff } from 'lucide-vue-next'
 //import { setupMessaging } from '@/firebase'
 
 const email = ref('')
 const password = ref('')
 const loading = ref(false)
+const showPassword = ref(false)
 const router = useRouter()
 const userStore = useUserStore()
 const accountStore = useAccountStore()
 const scoreStore = useScoreStore()
+
+function togglePassword() {
+    showPassword.value = !showPassword.value
+}
 
 async function handleLogin() {
     if (!email.value || !password.value) {

--- a/src/pages/auth/ResetPassword.vue
+++ b/src/pages/auth/ResetPassword.vue
@@ -28,15 +28,30 @@
 
                 <!-- 비밀번호 입력 -->
                 <div class="w-full flex flex-col gap-1">
-                    <div class="flex items-center border border-gray-300 rounded-md px-3 py-2">
+                    <div
+                        class="relative flex items-center border border-gray-300 rounded-md px-3 py-2"
+                    >
                         <span class="mr-2 text-lg">🔒</span>
                         <input
                             v-model="password"
-                            type="password"
+                            :type="showPassword ? 'text' : 'password'"
                             placeholder="새 비밀번호 입력"
                             class="flex-1 text-sm sm:text-base placeholder-gray-400 focus:outline-none"
                             :disabled="sending"
+                            autocomplete="new-password"
+                            inputmode="text"
                         />
+                        <!-- 눈 아이콘 버튼 -->
+                        <button
+                            type="button"
+                            @click="togglePassword"
+                            :aria-pressed="showPassword"
+                            aria-label="비밀번호 표시 전환"
+                            class="absolute right-2 text-gray-500 hover:text-black p-1"
+                        >
+                            <Eye v-if="!showPassword" class="w-5 h-5" />
+                            <EyeOff v-else class="w-5 h-5" />
+                        </button>
                     </div>
                     <p v-if="password && !isPasswordValid" class="text-red-500 text-sm">
                         비밀번호는 문자와 숫자를 모두 포함하여 8~20자여야 합니다.
@@ -45,15 +60,30 @@
 
                 <!-- 비밀번호 확인 -->
                 <div class="w-full flex flex-col gap-1">
-                    <div class="flex items-center border border-gray-300 rounded-md px-3 py-2">
+                    <div
+                        class="relative flex items-center border border-gray-300 rounded-md px-3 py-2"
+                    >
                         <span class="mr-2 text-lg">🔒</span>
                         <input
                             v-model="confirmPassword"
-                            type="password"
+                            :type="showConfirm ? 'text' : 'password'"
                             placeholder="비밀번호 확인"
                             class="flex-1 text-sm sm:text-base placeholder-gray-400 focus:outline-none"
                             :disabled="sending"
+                            autocomplete="new-password"
+                            inputmode="text"
                         />
+                        <!-- 눈 아이콘 버튼 -->
+                        <button
+                            type="button"
+                            @click="toggleConfirm"
+                            :aria-pressed="showConfirm"
+                            aria-label="비밀번호 확인 표시 전환"
+                            class="absolute right-2 text-gray-500 hover:text-black p-1"
+                        >
+                            <Eye v-if="!showConfirm" class="w-5 h-5" />
+                            <EyeOff v-else class="w-5 h-5" />
+                        </button>
                     </div>
                     <p v-if="confirmPassword && !isPasswordMatch" class="text-red-500 text-sm">
                         비밀번호가 일치하지 않습니다.
@@ -77,7 +107,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { ArrowLeft as LucideArrowLeft } from 'lucide-vue-next'
+import { ArrowLeft as LucideArrowLeft, Eye, EyeOff } from 'lucide-vue-next'
 import authApi from '@/api/authApi'
 
 // router & route
@@ -96,10 +126,14 @@ const password = ref('')
 const confirmPassword = ref('')
 const sending = ref(false)
 
+// 보기/숨기기 상태
+const showPassword = ref(false)
+const showConfirm = ref(false)
+const togglePassword = () => (showPassword.value = !showPassword.value)
+const toggleConfirm = () => (showConfirm.value = !showConfirm.value)
+
 // 뒤로가기
-const goBack = () => {
-    router.back()
-}
+const goBack = () => router.back()
 
 // 비밀번호 유효성: 문자+숫자 포함 8~20자
 const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/

--- a/src/pages/auth/SignUp.vue
+++ b/src/pages/auth/SignUp.vue
@@ -63,12 +63,26 @@
             <!-- 비밀번호 -->
             <div>
                 <label class="text-base font-medium block mb-2">비밀번호</label>
-                <input
-                    v-model="password"
-                    type="password"
-                    placeholder="비밀번호를 입력해 주세요."
-                    class="w-full border-b border-gray-300 py-2 text-base focus:outline-none"
-                />
+                <div class="relative">
+                    <input
+                        v-model="password"
+                        :type="showPassword ? 'text' : 'password'"
+                        placeholder="비밀번호를 입력해 주세요."
+                        class="w-full border-b border-gray-300 py-2 text-base focus:outline-none pr-8"
+                        autocomplete="new-password"
+                        inputmode="text"
+                    />
+                    <button
+                        type="button"
+                        @click="togglePassword"
+                        :aria-pressed="showPassword"
+                        aria-label="비밀번호 표시 전환"
+                        class="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-black"
+                    >
+                        <Eye v-if="!showPassword" class="w-5 h-5" />
+                        <EyeOff v-else class="w-5 h-5" />
+                    </button>
+                </div>
                 <p v-if="password && !isPasswordValid" class="text-red-500 text-sm mt-1">
                     비밀번호는 문자와 숫자를 모두 포함하여 8~20자여야 합니다.
                 </p>
@@ -77,12 +91,26 @@
             <!-- 비밀번호 확인 -->
             <div>
                 <label class="text-base font-medium block mb-2">비밀번호 확인</label>
-                <input
-                    v-model="confirmPassword"
-                    type="password"
-                    placeholder="비밀번호를 다시 입력해 주세요."
-                    class="w-full border-b border-gray-300 py-2 text-base focus:outline-none"
-                />
+                <div class="relative">
+                    <input
+                        v-model="confirmPassword"
+                        :type="showConfirm ? 'text' : 'password'"
+                        placeholder="비밀번호를 다시 입력해 주세요."
+                        class="w-full border-b border-gray-300 py-2 text-base focus:outline-none pr-8"
+                        autocomplete="new-password"
+                        inputmode="text"
+                    />
+                    <button
+                        type="button"
+                        @click="toggleConfirm"
+                        :aria-pressed="showConfirm"
+                        aria-label="비밀번호 확인 표시 전환"
+                        class="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-black"
+                    >
+                        <Eye v-if="!showConfirm" class="w-5 h-5" />
+                        <EyeOff v-else class="w-5 h-5" />
+                    </button>
+                </div>
                 <p v-if="confirmPassword && !isPasswordMatch" class="text-red-500 text-sm mt-1">
                     비밀번호가 일치하지 않습니다.
                 </p>
@@ -145,6 +173,7 @@
                     <input type="checkbox" v-model="agreeAll" @change="toggleAll" />
                     모두 동의합니다
                 </label>
+
                 <label class="flex items-center gap-2">
                     <input type="checkbox" v-model="terms.service" />
                     [필수] 이용약관
@@ -184,7 +213,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { ArrowLeft as LucideArrowLeft } from 'lucide-vue-next'
+import { ArrowLeft as LucideArrowLeft, Eye, EyeOff } from 'lucide-vue-next'
 import PrimaryButton from '@/components/common/PrimaryButton.vue'
 import TermsModal from '@/components/modal/TermsModal.vue'
 import PrivacyModal from '@/components/modal/PrivacyModal.vue'
@@ -202,6 +231,12 @@ const confirmPassword = ref('')
 const name = ref('')
 const address = ref('')
 const birth = ref('')
+
+// 보기/숨기기 상태 + 토글
+const showPassword = ref(false)
+const showConfirm = ref(false)
+const togglePassword = () => (showPassword.value = !showPassword.value)
+const toggleConfirm = () => (showConfirm.value = !showConfirm.value)
 
 // email 인증 상태
 const sending = ref(false)


### PR DESCRIPTION
## 📌 PR 제목 예시
feat: 비밀번호 보기 가리기 기능 추가

---

## ✨ 변경 사항
- 로그인, 비밀번호 재설정, 회원가입 페이지에 비밀번호 보기, 가리기 기능 추가

---

## 🧪 테스트 방법
1. 로그인, 비밀번호 재설정, 회원가입 페이지 각각 들어가서 비밀번호 가리기, 보기 기능 시험해보기

---

## 🔍 관련 이슈

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
