### PR TITLE
profile_image_fix

### DIFF
--- a/src/components/modal/ModalBase.vue
+++ b/src/components/modal/ModalBase.vue
@@ -46,8 +46,12 @@
                                 <ChevronRight color="gray" size="14px" />
                             </div>
                         </div>
-                        <div class="gap-2">
-                            <img src="@/assets/images/zibi_2.png" alt="egg" class="w-16 h-16" />
+                        <div class="w-16 h-16 overflow-hidden rounded-full shrink-0">
+                            <img
+                                src="@/assets/images/zibi_2.png"
+                                alt="egg"
+                                class="w-full h-full object-cover"
+                            />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## 📌 PR 제목 예시
style: 사이드바 프로필 이미지 크기 고정

---

## ✨ 변경 사항
- 사이드바 프로필 이미지 화면 크기에 따라 깨지는 부분 수정

---

## 🧪 테스트 방법
1. 사이드바 프로필 이미지를 화면 크기 바꿔가며 안깨지는지 확인해보기
---

## 🔍 관련 이슈
---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
